### PR TITLE
refactor: migrate flat root screens to (stack) group folder structure

### DIFF
--- a/app/(stack)/confirmPhoto.js
+++ b/app/(stack)/confirmPhoto.js
@@ -10,14 +10,14 @@ import {
   Dimensions
 } from "react-native";
 import { useRouter, useNavigation } from "expo-router"; // ✅ useNavigation 추가
-import IconButton from "../components/IconButton";
-import { useAuth } from "../contexts/AuthContext";
-import { usePhoto } from "../contexts/PhotoContext";
-import { formatGridData } from "../utils/formatGridData";
+import IconButton from "../../components/IconButton";
+import { useAuth } from "../../contexts/AuthContext";
+import { usePhoto } from "../../contexts/PhotoContext";
+import { formatGridData } from "../../utils/formatGridData";
 import Constants from "expo-constants";
-import { useDiary } from "../contexts/DiaryContext";
+import { useDiary } from "../../contexts/DiaryContext";
 import { useMemo } from "react";
-// import CreationFlowProgress from "../components/CreationFlowProgress";
+// import CreationFlowProgress from "../../components/CreationFlowProgress";
 
 const { BACKEND_URL } = Constants.expoConfig.extra;
 const SCREEN_WIDTH = Dimensions.get("window").width;
@@ -147,7 +147,7 @@ export default function confirmPhoto() {
     <View style={styles.container}>
       <View style={[styles.header, photoList.length <= 9 && { marginBottom: 30 }]}>
         <IconButton
-          source={require("../assets/icons/backicon.png")}
+          source={require("../../assets/icons/backicon.png")}
           hsize={22}
           wsize={22}
           style={styles.back}
@@ -183,7 +183,7 @@ export default function confirmPhoto() {
                   <>
                     <View style={styles.overlay} />
                     <Image
-                      source={require("../assets/icons/pinkcheckicon.png")}
+                      source={require("../../assets/icons/pinkcheckicon.png")}
                       style={styles.checkIcon}
                     />
                   </>

--- a/app/(stack)/create.js
+++ b/app/(stack)/create.js
@@ -4,16 +4,16 @@ import { Menu, Divider } from "react-native-paper";
 import { KeyboardAvoidingView, Platform, View, StyleSheet, ScrollView } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 
-import HeaderDate from "../components/Header/HeaderDate";
-import IconButton from "../components/IconButton";
-import TextBox from "../components/TextBox";
-import characterList from "../assets/characterList";
-import { useDiary } from "../contexts/DiaryContext";
-import { usePhoto } from "../contexts/PhotoContext"; // ✅ 추가
-import { useAuth } from "../contexts/AuthContext";
-import { clearAllTempPhotos } from "../utils/clearTempPhotos";
-import { openGalleryAndUpload } from "../utils/openGalleryAndUpload";
-import CharacterPickerOverlay from "../components/CharacterPickerOverlay";
+import HeaderDate from "../../components/Header/HeaderDate";
+import IconButton from "../../components/IconButton";
+import TextBox from "../../components/TextBox";
+import characterList from "../../assets/characterList";
+import { useDiary } from "../../contexts/DiaryContext";
+import { usePhoto } from "../../contexts/PhotoContext"; // ✅ 추가
+import { useAuth } from "../../contexts/AuthContext";
+import { clearAllTempPhotos } from "../../utils/clearTempPhotos";
+import { openGalleryAndUpload } from "../../utils/openGalleryAndUpload";
+import CharacterPickerOverlay from "../../components/CharacterPickerOverlay";
 import Constants from "expo-constants";
 
 export default function CreatePage() {
@@ -139,7 +139,7 @@ export default function CreatePage() {
                   onDismiss={() => setMenuVisible(false)}
                   anchor={
                     <IconButton
-                      source={require("../assets/icons/bigpinkplusicon.png")}
+                      source={require("../../assets/icons/bigpinkplusicon.png")}
                       wsize={50}
                       hsize={50}
                       onPress={() => {

--- a/app/(stack)/edit.js
+++ b/app/(stack)/edit.js
@@ -11,18 +11,18 @@ import {
 import { useNavigation } from "@react-navigation/native";
 import { useLayoutEffect } from "react";
 import { useRouter } from "expo-router";
-import HeaderDate from "../components/Header/HeaderDate";
-import IconButton from "../components/IconButton";
-import TextBox from "../components/TextBox";
-import characterList from "../assets/characterList";
-import { usePhoto } from "../contexts/PhotoContext";
-import CharacterPickerOverlay from "../components/CharacterPickerOverlay";
-import EditImageSlider from "../components/EditImageSlider";
-import { useDiary } from "../contexts/DiaryContext";
-import { useAuth } from "../contexts/AuthContext";
+import HeaderDate from "../../components/Header/HeaderDate";
+import IconButton from "../../components/IconButton";
+import TextBox from "../../components/TextBox";
+import characterList from "../../assets/characterList";
+import { usePhoto } from "../../contexts/PhotoContext";
+import CharacterPickerOverlay from "../../components/CharacterPickerOverlay";
+import EditImageSlider from "../../components/EditImageSlider";
+import { useDiary } from "../../contexts/DiaryContext";
+import { useAuth } from "../../contexts/AuthContext";
 import Constants from "expo-constants";
-import ConfirmModal from "../components/Modal/ConfirmModal";
-import { openGalleryAndAdd } from "../utils/openGalleryAndAdd";
+import ConfirmModal from "../../components/Modal/ConfirmModal";
+import { openGalleryAndAdd } from "../../utils/openGalleryAndAdd";
 
 function buildEditSnapshot({ text, selectedCharacter, photos, mainPhotoId }) {
   return JSON.stringify({
@@ -350,7 +350,7 @@ export default function EditPage() {
             />
             <View style={styles.rightButtons}>
               <IconButton
-                source={require("../assets/icons/aipencilicon.png")}
+                source={require("../../assets/icons/aipencilicon.png")}
                 wsize={24}
                 hsize={24}
                 onPress={

--- a/app/(stack)/editWithAi.js
+++ b/app/(stack)/editWithAi.js
@@ -17,14 +17,14 @@ import { WebView } from "react-native-webview";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import Constants from "expo-constants";
-import { useAuth } from "../contexts/AuthContext";
-import { useDiary } from "../contexts/DiaryContext";
-import { usePhoto } from "../contexts/PhotoContext";
-import HeaderDate from "../components/Header/HeaderDate";
-import characterList from "../assets/characterList";
-import IconButton from "../components/IconButton";
-import ImageSlider from "../components/ImageSlider";
-import ConfirmModal from "../components/Modal/ConfirmModal";
+import { useAuth } from "../../contexts/AuthContext";
+import { useDiary } from "../../contexts/DiaryContext";
+import { usePhoto } from "../../contexts/PhotoContext";
+import HeaderDate from "../../components/Header/HeaderDate";
+import characterList from "../../assets/characterList";
+import IconButton from "../../components/IconButton";
+import ImageSlider from "../../components/ImageSlider";
+import ConfirmModal from "../../components/Modal/ConfirmModal";
 import { useNavigation } from "@react-navigation/native";
 
 function sanitizeEditTokens(value) {
@@ -434,8 +434,8 @@ export default function EditWithAIPage() {
               <IconButton
                 source={
                   isGridView
-                    ? require("../assets/icons/oneviewicon.png")
-                    : require("../assets/icons/viewicon.png")
+                    ? require("../../assets/icons/oneviewicon.png")
+                    : require("../../assets/icons/viewicon.png")
                 }
                 wsize={24}
                 hsize={24}
@@ -468,7 +468,7 @@ export default function EditWithAIPage() {
                 javaScriptEnabled
                 domStorageEnabled
                 scrollEnabled={false}
-                source={require("../assets/html/editor.html")}
+                source={require("../../assets/html/editor.html")}
                 onLoadEnd={onWebViewLoadEnd}
                 onMessage={handleMessage}
                 style={[
@@ -539,7 +539,7 @@ export default function EditWithAIPage() {
 
               <View style={styles.iconButtons}>
                 <IconButton
-                  source={require("../assets/icons/highlightingicon.png")}
+                  source={require("../../assets/icons/highlightingicon.png")}
                   wsize={32}
                   hsize={32}
                   onPress={() => {
@@ -551,7 +551,7 @@ export default function EditWithAIPage() {
                 />
                 <View style={{ height: 10 }} />
                 <IconButton
-                  source={require("../assets/icons/submiticon.png")}
+                  source={require("../../assets/icons/submiticon.png")}
                   wsize={32}
                   hsize={32}
                   onPress={handleSubmit}

--- a/app/(stack)/generate.js
+++ b/app/(stack)/generate.js
@@ -15,13 +15,13 @@ import {
 import { useRouter } from "expo-router";
 import DraggableFlatList from "react-native-draggable-flatlist";
 import * as Haptics from "expo-haptics";
-import IconButton from "../components/IconButton";
-import { useAuth } from "../contexts/AuthContext";
-import { usePhoto } from "../contexts/PhotoContext";
+import IconButton from "../../components/IconButton";
+import { useAuth } from "../../contexts/AuthContext";
+import { usePhoto } from "../../contexts/PhotoContext";
 import Constants from "expo-constants";
-import ConfirmModal from "../components/Modal/ConfirmModal";
-import colors from "../constants/colors";
-// import CreationFlowProgress from "../components/CreationFlowProgress";
+import ConfirmModal from "../../components/Modal/ConfirmModal";
+import colors from "../../constants/colors";
+// import CreationFlowProgress from "../../components/CreationFlowProgress";
 
 const screenWidth = Dimensions.get("window").width;
 const CARD_WIDTH = screenWidth - 112;
@@ -405,7 +405,7 @@ export default function GeneratePage() {
     <View style={styles.container}>
       <View style={styles.header}>
         <IconButton
-          source={require("../assets/icons/backicon.png")}
+          source={require("../../assets/icons/backicon.png")}
           hsize={22}
           wsize={22}
           onPress={() => {
@@ -504,7 +504,7 @@ export default function GeneratePage() {
                         }}
                       >
                         <Image
-                          source={require("../assets/icons/xicon.png")}
+                          source={require("../../assets/icons/xicon.png")}
                           style={styles.closeIconImg}
                         />
                       </TouchableOpacity>

--- a/app/(stack)/loading/_layout.js
+++ b/app/(stack)/loading/_layout.js
@@ -1,0 +1,12 @@
+import { Stack } from "expo-router";
+
+export default function LoadingLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        gestureEnabled: false
+      }}
+    />
+  );
+}

--- a/app/(stack)/loading/index.js
+++ b/app/(stack)/loading/index.js
@@ -2,12 +2,12 @@ import { View, Text, ActivityIndicator, StyleSheet } from "react-native";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "expo-router";
 import Constants from "expo-constants";
-import { useAuth } from "../contexts/AuthContext";
-import IconButton from "../components/IconButton";
-import { usePhoto } from "../contexts/PhotoContext";
-import ConfirmModal from "../components/Modal/ConfirmModal";
+import { useAuth } from "../../../contexts/AuthContext";
+import IconButton from "../../../components/IconButton";
+import { usePhoto } from "../../../contexts/PhotoContext";
+import ConfirmModal from "../../../components/Modal/ConfirmModal";
 import { useNavigation } from "@react-navigation/native";
-// import CreationFlowProgress from "../components/CreationFlowProgress";
+// import CreationFlowProgress from "../../../components/CreationFlowProgress";
 
 const { BACKEND_URL } = Constants.expoConfig.extra;
 

--- a/app/(stack)/loading/loadingDiary.js
+++ b/app/(stack)/loading/loadingDiary.js
@@ -3,12 +3,12 @@ import { View, ActivityIndicator, StyleSheet, Text, TouchableOpacity } from "rea
 import { Stack, useRouter, useLocalSearchParams } from "expo-router";
 import Constants from "expo-constants";
 import { useNavigation } from "@react-navigation/native";
-import { useAuth } from "../../contexts/AuthContext";
-import { useDiary } from "../../contexts/DiaryContext";
+import { useAuth } from "../../../contexts/AuthContext";
+import { useDiary } from "../../../contexts/DiaryContext";
 import { DeviceEventEmitter } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
-import colors from "../../constants/colors";
-// import CreationFlowProgress from "../../components/CreationFlowProgress";
+import colors from "../../../constants/colors";
+// import CreationFlowProgress from "../../../components/CreationFlowProgress";
 
 const POLLING_INTERVAL_MS = 8000;
 const MAX_POLL_RETRIES = 30;
@@ -142,7 +142,7 @@ export default function LoadingDiary() {
 
       if (isMounted.current) {
         console.warn("⚠️ Polling 실패: 홈으로 이동");
-        router.replace("/home");
+        router.replace("/(tabs)");
       } else {
         console.log("⛔️ 포커스 사라짐 - 홈 이동 생략");
       }
@@ -216,11 +216,11 @@ export default function LoadingDiary() {
         }
       } else {
         console.warn("❗예상치 못한 상태:", json?.status);
-        router.replace("/home");
+        router.replace("/(tabs)");
       }
     } catch (err) {
       console.error("📛 일기 생성 실패:", err);
-      router.replace("/home");
+      router.replace("/(tabs)");
     }
   }, [
     BACKEND_URL,

--- a/app/(stack)/loading/loadingPicture.js
+++ b/app/(stack)/loading/loadingPicture.js
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { View, ActivityIndicator, StyleSheet, Text, SafeAreaView } from "react-native";
 import { Stack, useRouter } from "expo-router";
 import { useNavigation } from "@react-navigation/native";
-import CreationFlowProgress from "../../components/CreationFlowProgress";
+import CreationFlowProgress from "../../../components/CreationFlowProgress";
 
 export default function LoadingPage() {
   const nav = useRouter();

--- a/app/(stack)/search.js
+++ b/app/(stack)/search.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { View, FlatList, StyleSheet, Text, Image, TouchableOpacity } from "react-native";
-import HeaderSearch from "../components/Header/HeaderSearch";
+import HeaderSearch from "../../components/Header/HeaderSearch";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { format, parse } from "date-fns";
 

--- a/app/(stack)/write.js
+++ b/app/(stack)/write.js
@@ -2,19 +2,19 @@ import { useState, useEffect, useCallback, useMemo, useRef, useLayoutEffect } fr
 import { KeyboardAvoidingView, Platform, View, StyleSheet, ScrollView, Text } from "react-native";
 import { useRouter } from "expo-router";
 import { useNavigation } from "@react-navigation/native";
-import CharacterPickerOverlay from "../components/CharacterPickerOverlay";
-import HeaderDate from "../components/Header/HeaderDate";
-import IconButton from "../components/IconButton";
-import TextBox from "../components/TextBox";
-import characterList from "../assets/characterList";
-import { useDiary } from "../contexts/DiaryContext";
-import { usePhoto } from "../contexts/PhotoContext";
-import { useAuth } from "../contexts/AuthContext";
+import CharacterPickerOverlay from "../../components/CharacterPickerOverlay";
+import HeaderDate from "../../components/Header/HeaderDate";
+import IconButton from "../../components/IconButton";
+import TextBox from "../../components/TextBox";
+import characterList from "../../assets/characterList";
+import { useDiary } from "../../contexts/DiaryContext";
+import { usePhoto } from "../../contexts/PhotoContext";
+import { useAuth } from "../../contexts/AuthContext";
 import Constants from "expo-constants";
-import EditImageSlider from "../components/EditImageSlider";
-import { openGalleryAndAdd } from "../utils/openGalleryAndAdd";
-import ConfirmModal from "../components/Modal/ConfirmModal";
-import colors from "../constants/colors";
+import EditImageSlider from "../../components/EditImageSlider";
+import { openGalleryAndAdd } from "../../utils/openGalleryAndAdd";
+import ConfirmModal from "../../components/Modal/ConfirmModal";
+import colors from "../../constants/colors";
 
 const MAX_PHOTO_COUNT = 9;
 

--- a/app/_layout.js
+++ b/app/_layout.js
@@ -1,5 +1,5 @@
 // app/_layout.js
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import "react-native-reanimated";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { Stack, useRouter, useSegments } from "expo-router";
@@ -74,7 +74,7 @@ function RootLayoutNav() {
       }
 
       if (!inAuthGroup && (openSegment === "" || openSegment === "login")) {
-        router.replace("/home");
+        router.replace("/(tabs)");
       }
     };
 
@@ -129,7 +129,7 @@ function RootLayoutNav() {
         }}
       >
         <Stack.Screen
-          name="search"
+          name="(stack)/search"
           options={{
             presentation: "fullScreenModal",
             animation: "fade",

--- a/app/diary/_layout.js
+++ b/app/diary/_layout.js
@@ -1,5 +1,4 @@
 // app/diary/_layout.js
-import React from "react";
 import { Stack } from "expo-router";
 
 export default function DiaryLayout() {
@@ -8,7 +7,8 @@ export default function DiaryLayout() {
       <Stack
         screenOptions={{
           headerShown: false,
-          contentStyle: { backgroundColor: "#FCF9F4" }
+          contentStyle: { backgroundColor: "#FCF9F4" },
+          gestureEnabled: false
         }}
       />
     </>

--- a/app/home.js
+++ b/app/home.js
@@ -1,8 +1,0 @@
-// app/home.js
-import React from "react";
-import { Redirect } from "expo-router";
-
-export default function HomeRedirect() {
-  // /home 에 진입하면 바로 '/'로 리다이렉트
-  return <Redirect href="/" />;
-}

--- a/app/login.js
+++ b/app/login.js
@@ -87,7 +87,7 @@ export default function Login() {
       });
 
       const requiredAgreed = await checkRequiredAgreed();
-      router.replace(requiredAgreed ? "/home" : "/terms");
+      router.replace(requiredAgreed ? "/(tabs)" : "/(onboarding)/terms");
     } catch (e) {
       // console.error("Apple 로그인 오류:", e);
       // Alert.alert("Apple 로그인 실패", e.message ?? "알 수 없는 오류");
@@ -126,7 +126,7 @@ export default function Login() {
       });
 
       const requiredAgreed = await checkRequiredAgreed();
-      router.replace(requiredAgreed ? "/home" : "/terms");
+      router.replace(requiredAgreed ? "/(tabs)" : "/(onboarding)/terms");
     } catch (e) {
       // console.error("네이버 로그인 처리 오류:", e);
       // Alert.alert("네이버 로그인 실패", e.message ?? "알 수 없는 오류");
@@ -161,7 +161,7 @@ export default function Login() {
       });
 
       const requiredAgreed = await checkRequiredAgreed();
-      router.replace(requiredAgreed ? "/home" : "/terms");
+      router.replace(requiredAgreed ? "/(tabs)" : "/(onboarding)/terms");
     } catch (e) {
       // console.error("Kakao login error", e);
       // Alert.alert("카카오 로그인 실패", e.message ?? "알 수 없는 오류");


### PR DESCRIPTION
- Move 9 root-level screens (create, write, edit, editWithAi, generate, confirmPhoto, search, loading, loading/) into app/(stack)/ group folder
- Move loading/ subfolder into (stack)/loading/ with _layout.js (gestureEnabled: false applied via layout instead of per-screen)
- Convert loading.js → loading/index.js to resolve naming conflict with loading/ directory
- Fix diary/_layout.js: remove orphaned Stack.Screen without parent Stack
- Update all relative imports after path depth changes
- Replace /home redirects with /(tabs) and delete home.js (was a no-op redirect)
- Fix login.js: /terms → /(onboarding)/terms